### PR TITLE
Fix Atom feed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'html-proofer'
+gem 'jekyll-feed'


### PR DESCRIPTION
The Jekyll-feed was added as a plugin but the gem was not added as per the documentation here:
https://github.com/jekyll/jekyll-feed